### PR TITLE
#14: add `samconfig` version

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,3 +1,5 @@
+version = 0.1
+
 [default]
 [default.global.parameters]
 stack_name = "bixi-api"


### PR DESCRIPTION
## Description

Fix samconfig version removed by mistake.

## Related Issue

#14

## Changes Made

- [x] put back samconfig version

## Checklist

- [x] I have tested these changes locally.
